### PR TITLE
Manipulator Public Matrix Access

### DIFF
--- a/src/Gnomon/MainWindow.xaml
+++ b/src/Gnomon/MainWindow.xaml
@@ -9,8 +9,18 @@
         Title="MainWindow" Height="350" Width="525"
         Activated="window_Activated">
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Button
+            x:Name="ChangeCameraButton"
+            Grid.Row="0" 
+            Content="Change Camera"
+            Click="ChangeCameraButton_OnClick"/>
         <wpf:VeldridSceneGraphControl 
             x:Name="VSGElement"
+            Grid.Row="1"
             SceneRoot="{Binding SceneRoot}"
             CameraManipulator="{Binding CameraManipulator}"
             EventHandler="{Binding EventHandler}"
@@ -18,6 +28,7 @@
         </wpf:VeldridSceneGraphControl>
         
         <Border Height="100" Width="100"
+                Grid.Row="1"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Bottom">
             <wpf:VeldridSceneGraphControl 

--- a/src/Gnomon/MainWindow.xaml.cs
+++ b/src/Gnomon/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Numerics;
+using System.Windows;
 using Microsoft.Extensions.Logging;
 using Veldrid.SceneGraph;
 using Veldrid.SceneGraph.InputAdapter;
@@ -15,13 +16,21 @@ namespace Gnomon
     /// </summary>
     public partial class MainWindow
     {
+        private SceneViewModel _viewModel;
         private Matrix4x4 _gnomonStepBack = Matrix4x4.CreateTranslation(0, 0, -10.0f);
 
         public MainWindow()
         {
             InitializeComponent();
-            DataContext = new SceneViewModel();
+            _viewModel = new SceneViewModel();
+            DataContext = _viewModel;
         }
+
+        private void ChangeCameraButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            _viewModel.ChangeCamera(VSGElement.GetUiActionAdapter(), VSGElement.GetCamera());
+        }
+        
         private void window_Activated(object sender, EventArgs e)
         {
             var vm = DataContext as SceneViewModel;

--- a/src/Gnomon/MainWindow.xaml.cs
+++ b/src/Gnomon/MainWindow.xaml.cs
@@ -33,8 +33,7 @@ namespace Gnomon
         
         private void window_Activated(object sender, EventArgs e)
         {
-            var vm = DataContext as SceneViewModel;
-            vm.PropertyChanged += VmPropertyHandler;
+            _viewModel.PropertyChanged += VmPropertyHandler;
             
             BackOff();
         }
@@ -42,9 +41,8 @@ namespace Gnomon
         {
             if (e.PropertyName == "MainViewMatrix")
             {
-                var vm = DataContext as SceneViewModel;
                 Matrix4x4 matrix;
-                var ok = Matrix4x4.Decompose(vm.MainViewMatrix, out var scale, out var rotation, out var translation);
+                var ok = Matrix4x4.Decompose(_viewModel.MainViewMatrix, out var scale, out var rotation, out var translation);
                 if (ok)
                 {
                     matrix = Matrix4x4.CreateFromQuaternion(rotation);

--- a/src/Gnomon/SceneViewModel.cs
+++ b/src/Gnomon/SceneViewModel.cs
@@ -45,18 +45,6 @@ namespace Gnomon
             }
         }
         
-
-        private ICameraManipulator _gnomonCameraManipulator;
-
-        public ICameraManipulator GnomonCameraManipulator
-        {
-            get => _gnomonCameraManipulator;
-            set
-            {
-                _gnomonCameraManipulator = value;
-                OnPropertyChanged("_gnomonCameraManipulator");
-            }
-        }
         internal SceneViewModel()
         {
             SceneRoot = Examples.Common.PathExampleScene.Build();
@@ -68,7 +56,21 @@ namespace Gnomon
             GnomonRoot.AddChild(gnomon);
             
             EventHandler = new ViewMatrixEventHandler(this);
-            GnomonCameraManipulator = TrackballManipulator.Create();
+        }
+        
+        public void ChangeCamera(IUiActionAdapter uiActionAdapter, ICamera camera)
+        {
+            var up = new Vector3(0.0f, 0.0f, 1.0f);
+            var t = SceneRoot.GetBound();
+            var angle = 90.0f * 0.01745329252f; // 90 degrees in radians
+            var eye = new Vector3(0, t.Radius+10.0f, 0);
+            var rotation = Matrix4x4.CreateRotationZ(angle);
+            eye = Vector3.Transform(eye, rotation);
+                            
+            if (!(CameraManipulator is StandardManipulator cameraManipulator)) return;
+            cameraManipulator.SetTransformation(eye, t.Center, up);
+
+            MainViewMatrix = cameraManipulator.InverseMatrix;
         }
     }
 }

--- a/src/Gnomon/ViewMatrixEventHandler.cs
+++ b/src/Gnomon/ViewMatrixEventHandler.cs
@@ -12,6 +12,8 @@
 // and may not be used in any way not expressly authorized by the Company.
 //
 
+using System.Numerics;
+using Veldrid;
 using Veldrid.SceneGraph.InputAdapter;
 
 namespace Gnomon
@@ -28,7 +30,30 @@ namespace Gnomon
 
         public override void HandleInput(IInputStateSnapshot snapshot, IUiActionAdapter uiActionAdapter)
         {
+            base.HandleInput(snapshot, uiActionAdapter);
             _viewModel.MainViewMatrix = snapshot.ViewMatrix;
+            
+            foreach (var keyEvent in snapshot.KeyEvents)
+            {
+                if (keyEvent.Down)
+                {
+                    switch (keyEvent.Key)
+                    {
+                        case Key.X:
+                            var up = new Vector3(0.0f, 0.0f, 1.0f);
+                            var t = _viewModel.SceneRoot.GetBound();
+                            var angle = 90.0f * 0.01745329252f; // 90 degrees in radians
+                            var eye = new Vector3(0, t.Radius+10.0f, 0);
+                            var rotation = Matrix4x4.CreateRotationZ(angle);
+                            eye = Vector3.Transform(eye, rotation);
+                            
+                            if (!(_viewModel.CameraManipulator is StandardManipulator cameraManipulator)) return;
+                            cameraManipulator.SetTransformation(eye, t.Center, up);
+                            // MainViewMatrix = MainCameraViewMatrix;
+                            break;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Gnomon/ViewMatrixEventHandler.cs
+++ b/src/Gnomon/ViewMatrixEventHandler.cs
@@ -32,28 +32,6 @@ namespace Gnomon
         {
             base.HandleInput(snapshot, uiActionAdapter);
             _viewModel.MainViewMatrix = snapshot.ViewMatrix;
-            
-            foreach (var keyEvent in snapshot.KeyEvents)
-            {
-                if (keyEvent.Down)
-                {
-                    switch (keyEvent.Key)
-                    {
-                        case Key.X:
-                            var up = new Vector3(0.0f, 0.0f, 1.0f);
-                            var t = _viewModel.SceneRoot.GetBound();
-                            var angle = 90.0f * 0.01745329252f; // 90 degrees in radians
-                            var eye = new Vector3(0, t.Radius+10.0f, 0);
-                            var rotation = Matrix4x4.CreateRotationZ(angle);
-                            eye = Vector3.Transform(eye, rotation);
-                            
-                            if (!(_viewModel.CameraManipulator is StandardManipulator cameraManipulator)) return;
-                            cameraManipulator.SetTransformation(eye, t.Center, up);
-                            // MainViewMatrix = MainCameraViewMatrix;
-                            break;
-                    }
-                }
-            }
         }
     }
 }

--- a/src/Veldrid.SceneGraph/InputAdapter/CameraManipulator.cs
+++ b/src/Veldrid.SceneGraph/InputAdapter/CameraManipulator.cs
@@ -45,7 +45,7 @@ namespace Veldrid.SceneGraph.InputAdapter
     
     public abstract class CameraManipulator : InputEventHandler, ICameraManipulator
     {
-        protected abstract Matrix4x4 InverseMatrix { get; }
+        public abstract Matrix4x4 InverseMatrix { get; }
         
         protected abstract float ZoomScale { get; }
         

--- a/src/Veldrid.SceneGraph/InputAdapter/OrbitManipulator.cs
+++ b/src/Veldrid.SceneGraph/InputAdapter/OrbitManipulator.cs
@@ -48,7 +48,7 @@ namespace Veldrid.SceneGraph.InputAdapter
         
         private Matrix4x4 _viewMatrix = Matrix4x4.Identity;
 
-        protected override Matrix4x4 InverseMatrix =>
+        public override Matrix4x4 InverseMatrix =>
             Matrix4x4.CreateTranslation(-_center) *
             Matrix4x4.CreateFromQuaternion(Quaternion.Inverse(_rotation)) *
             Matrix4x4.CreateTranslation(new Vector3(0.0f, 0.0f, -_distance));


### PR DESCRIPTION
Provide public access to the modelview matrix generated by the manipulator and applied to the camera.

The use case is described in the sample code. This provide a viewmodel a way of knowing how the manipulator is going to update the camera. It is useful when programmatically setting the manipulator.

There may be a better approach, but attempting to bind to the camera ViewMatrix failed. For purposes of the gnomon and a slaved camera view, I considered a specialized camera manipulator but that would still be dependent on some trigger/event to indicate the master had updated.